### PR TITLE
Fix pre-existing CI failures on macOS Intel and model download tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,22 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Cancel a running PR check when new commits are pushed, so a wedged run does not
+# keep burning runner hours after it has been superseded. Pushes to main still run
+# to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
     continue-on-error: false
-    # The slowest passing job takes ~30 min; this only needs to stop a wedged run from
-    # burning runner hours, pytest-timeout is what bounds individual tests.
-    timeout-minutes: 60
+    # Backstop for a wedged run: the fork/TensorFlow deadlock hangs in native code
+    # holding the GIL, which pytest-timeout cannot interrupt in either method, so the
+    # job-level limit is what stops it. Slowest healthy job is ~32 min; 50 leaves
+    # headroom while capping a hang's cost.
+    timeout-minutes: 50
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
     continue-on-error: false
-    timeout-minutes: 360
+    # The slowest passing job takes ~30 min; this only needs to stop a wedged run from
+    # burning runner hours, pytest-timeout is what bounds individual tests.
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,11 @@ namespaces = true
 log_cli = true
 log_level = "DEBUG"
 timeout = 300
+# The signal method cannot interrupt a thread blocked in a C call, so a deadlocked
+# fork child let the run hang until the job limit killed it hours later. The thread
+# method kills the process instead, turning such hangs into a failure with a stack
+# dump. Windows already uses it, since it has no SIGALRM.
+timeout_method = "thread"
 addopts = ["--max-worker-restart=0"]
 testpaths = ["src/birdnet_tests"]
 norecursedirs = ["src/birdnet_v1_tests"]

--- a/src/birdnet_tests/acoustic_models/inference/encoding/encoding_result_py/test_encoding_to_structured_array.py
+++ b/src/birdnet_tests/acoustic_models/inference/encoding/encoding_result_py/test_encoding_to_structured_array.py
@@ -17,6 +17,12 @@ from birdnet.utils.helper import (
 
 DEFAULT_EMBEDDING_DIM = 6
 
+# start_time/end_time are stored as float32 and, on numpy 1.x, the intermediate
+# products are computed in float32 as well (numpy 2 keeps them float64 via NEP 50).
+# Speeds that are not exactly representable therefore drift by ~1 ULP, which exceeds
+# the assert_allclose default rtol of 1e-7 - that is below float32 eps (~1.19e-7).
+_FLOAT32_TIME_RTOL = 1e-6
+
 
 def create_mock_encoding_tensor(
   n_files: int,
@@ -268,8 +274,12 @@ def test_time_calculations_speedup_one_tenth_no_overlap() -> None:
   expected_starts = np.arange(len(structured)) * hop
   expected_ends = np.minimum(expected_starts + 3.0 * 0.1, result.input_durations[0])
 
-  np.testing.assert_allclose(structured["start_time"], expected_starts)
-  np.testing.assert_allclose(structured["end_time"], expected_ends)
+  np.testing.assert_allclose(
+    structured["start_time"], expected_starts, rtol=_FLOAT32_TIME_RTOL
+  )
+  np.testing.assert_allclose(
+    structured["end_time"], expected_ends, rtol=_FLOAT32_TIME_RTOL
+  )
 
 
 def test_time_calculations_speedup_decimal_no_overlap() -> None:
@@ -289,8 +299,12 @@ def test_time_calculations_speedup_decimal_no_overlap() -> None:
     expected_starts + 3.0 * 0.1387434856, result.input_durations[0]
   )
 
-  np.testing.assert_allclose(structured["start_time"], expected_starts)
-  np.testing.assert_allclose(structured["end_time"], expected_ends)
+  np.testing.assert_allclose(
+    structured["start_time"], expected_starts, rtol=_FLOAT32_TIME_RTOL
+  )
+  np.testing.assert_allclose(
+    structured["end_time"], expected_ends, rtol=_FLOAT32_TIME_RTOL
+  )
 
 
 def _test_end_time_clipping_multiple_segments(

--- a/src/birdnet_tests/acoustic_models/v3_0/model_py/test_encode/test_acoustic_encode_model_v3_0.py
+++ b/src/birdnet_tests/acoustic_models/v3_0/model_py/test_encode/test_acoustic_encode_model_v3_0.py
@@ -10,6 +10,7 @@ from birdnet_tests.helper import (
   assert_encoding_result_is_close,
   ensure_onnxruntime_or_skip,
   ensure_torch_or_skip,
+  ensure_v3_0_torch_backend_or_skip,
 )
 from birdnet_tests.test_files import TEST_FILE_SHORT
 
@@ -23,6 +24,7 @@ _PT_ONNX_ENCODING_MEAN_ABS_DIFF = 1e-5
 def _load_model(backend: _Backend) -> AcousticModelV3_0:
   if backend == "pt":
     ensure_torch_or_skip()
+    ensure_v3_0_torch_backend_or_skip()
   else:
     ensure_onnxruntime_or_skip()
 
@@ -84,6 +86,7 @@ def test_v3_0_encode_respects_segment_size(
 
 def test_v3_0_encode_pt_and_onnx_are_close() -> None:
   ensure_torch_or_skip()
+  ensure_v3_0_torch_backend_or_skip()
   ensure_onnxruntime_or_skip()
 
   pt_model = load("acoustic", "3.0", "pt", precision="fp32")
@@ -108,6 +111,7 @@ def test_v3_0_encode_pt_and_onnx_are_close_with_custom_segment_size(
   segment_size_s: float,
 ) -> None:
   ensure_torch_or_skip()
+  ensure_v3_0_torch_backend_or_skip()
   ensure_onnxruntime_or_skip()
 
   pt_model = load("acoustic", "3.0", "pt", precision="fp32")

--- a/src/birdnet_tests/acoustic_models/v3_0/model_py/test_predict/test_acoustic_predict_model_v3_0.py
+++ b/src/birdnet_tests/acoustic_models/v3_0/model_py/test_predict/test_acoustic_predict_model_v3_0.py
@@ -10,6 +10,7 @@ from birdnet_tests.helper import (
   assert_prediction_result_is_close,
   ensure_onnxruntime_or_skip,
   ensure_torch_or_skip,
+  ensure_v3_0_torch_backend_or_skip,
 )
 from birdnet_tests.test_files import TEST_FILE_SHORT
 
@@ -23,6 +24,7 @@ _PT_ONNX_PREDICTION_MEAN_ABS_DIFF = 1e-5
 def _load_model(backend: _Backend) -> AcousticModelV3_0:
   if backend == "pt":
     ensure_torch_or_skip()
+    ensure_v3_0_torch_backend_or_skip()
   else:
     ensure_onnxruntime_or_skip()
 
@@ -98,6 +100,7 @@ def test_v3_0_predict_respects_segment_size(
 
 def test_v3_0_predict_pt_and_onnx_are_close() -> None:
   ensure_torch_or_skip()
+  ensure_v3_0_torch_backend_or_skip()
   ensure_onnxruntime_or_skip()
 
   pt_model = load("acoustic", "3.0", "pt", precision="fp32")
@@ -130,6 +133,7 @@ def test_v3_0_predict_pt_and_onnx_are_close_with_custom_segment_size(
   segment_size_s: float,
 ) -> None:
   ensure_torch_or_skip()
+  ensure_v3_0_torch_backend_or_skip()
   ensure_onnxruntime_or_skip()
 
   pt_model = load("acoustic", "3.0", "pt", precision="fp32")

--- a/src/birdnet_tests/conftest.py
+++ b/src/birdnet_tests/conftest.py
@@ -1,6 +1,19 @@
 import logging
 
+import pytest
+
 from birdnet.utils.logging_utils import get_package_logger
+
+# The v3.0 models are ~520 MiB and Zenodo serves them at roughly 2 MiB/s, so a single
+# download takes ~5-6 min. That sits right on the global 300s timeout, which cut the
+# downloads off just short of completion instead of letting them finish.
+LOAD_MODEL_TIMEOUT_S = 1800
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+  for item in items:
+    if item.get_closest_marker("load_model") is not None:
+      item.add_marker(pytest.mark.timeout(LOAD_MODEL_TIMEOUT_S))
 
 
 def pytest_configure() -> None:

--- a/src/birdnet_tests/helper.py
+++ b/src/birdnet_tests/helper.py
@@ -256,6 +256,14 @@ def ensure_not_intel_macos_or_skip() -> None:
     pytest.skip("Test not supported on Intel macOS systems")
 
 
+def ensure_v3_0_torch_backend_or_skip() -> None:
+  # torch 2.2.2 is the last release shipping x86 macOS wheels and is too old for the
+  # v3.0 TorchScript model: loading it succeeds, but the inference workers then die and
+  # the session is cancelled. The onnx backend works on the same machines.
+  if check_is_intel_macos():
+    pytest.skip("Acoustic model v3.0 needs a newer torch than Intel macOS provides")
+
+
 def ensure_gpu_or_skip_smi() -> None:
   gpu_available = False
   try:


### PR DESCRIPTION
Fixes three pre-existing failures on `main`. None of them originate from #54, but they are what is turning that PR's CI red.

## The `load_model` "download flakes" are the 300s timeout

They are not interrupted downloads, so retries would not have helped. The v3.0 models are ~520 MiB and Zenodo serves them at ~2 MiB/s, so a single download needs ~5-6 min against a global `timeout = 300`. The tqdm progress bars in [run 29565314026](https://github.com/birdnet-team/birdnet/actions/runs/29565314026) show them being killed mid-download at full speed:

| Job | Progress when killed |
|---|---|
| macos-15, 3.11 | **530M/542M** (98%, ~5s from finishing) |
| macos-15, 3.13 | 504M/542M (93%) |
| ubuntu-24.04-arm, 3.12 | 455M/542M (84%) |

This also explains why only the v3.0 models (~516 MiB) ever fail while the 13-73 MiB v2.4/geo models never do. The `Read on closed or unwrapped SSL socket` in the tracebacks is just pytest-timeout interrupting the read, not the cause.

`load_model` tests now get 1800s via a `pytest_collection_modifyitems` hook. Every other test keeps the 300s guard, so real hangs are still caught.

## Two real failures that were hidden behind it

Because tox stops at the first failing command, a timeout in the `load_model` run meant the rest of the suite never executed. The macos-15-intel 3.12 job on `main` did get past it, and shows both of these already present.

**Float32 time tolerance.** Not an x86-vs-ARM issue: it is numpy 1.26 vs 2.x promotion. `start_time`/`end_time` are float32, and on numpy 1.x the intermediate products stay float32 too, while numpy 2 widens them to float64 via NEP 50. Speeds that are not exactly representable therefore drift ~1 ULP. The tests asserted `assert_allclose`'s default `rtol=1e-7`, which is *below* float32 eps (~1.19e-7), so the assertion was never sound on float32 data. macOS Intel is the only runner pinned to numpy 1.26 (via `tensorflow <2.17`). Now `rtol=1e-6`; `start_time` was at 7.5e-8 and one perturbation from flaking, so both are loosened.

**v3.0 torch backend on macOS Intel.** `pt = ["torch >= 2.0.0"]` has no upper pin, so macOS Intel resolves torch 2.2.2 (the last x86 macOS wheel), which is too old for the v3.0 TorchScript model. `torch.jit.load` runs inside the inference worker rather than at model-load time, which is why `test_v3_0_pt` passes while every v3.0 pt inference test fails with `RuntimeError: Analysis was cancelled`. The onnx backend works on the same machines. Skipped via a new `ensure_v3_0_torch_backend_or_skip()`, matching the existing `tensorflow <2.17` pin pattern for that platform.

## Not addressed here

`test_tflite_fp32_twice_two_sessions_parallel_processes_fork` hangs nondeterministically (it timed out on ubuntu-24.04 / 3.12, passed on 3.11 and 3.13). It is the documented fork-in-a-multi-threaded-process hazard, matching the `QueueFeederThread` stacks stuck in `waiter.acquire()` - the same root cause as the existing `ensure_not_mac_or_skip()  # reason unknown` line.

Skipping it on Linux would make it dead code: `use_fork_or_skip()` only proceeds on Linux/macOS and macOS is already skipped. That is a delete-or-redesign decision, left for a follow-up. Note it will likely surface *more* often now that the suite actually runs to completion.

## Verification

- pytest-timeout resolves 1800s for all 5 `load_model` tests and 300s for everything else, checked through the plugin's own API.
- The float32 drift was reproduced locally at `1.0596381286823678e-07`, matching the CI log's `1.05963813e-07`; it fails at `rtol=1e-7` and passes at `1e-6`.
- The skip helper gates on Darwin/x86_64 only (arm64 macOS, Linux and Windows still run).
- 188 tests pass locally, including the v3.0 pt tests, confirming the skip does not over-apply.
- No new ruff or mypy findings; the pre-existing ones are identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)