### PR TITLE
Document prediction worker limits and cleanup

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -44,6 +44,40 @@ Predict species from multiple audio files in a directory
   predictions = model.predict("example/soundscapes/")
 
   predictions.to_csv("example/predictions.csv")
+
+Limit prediction worker processes
+---------------------------------
+
+``predict`` starts one worker process per physical CPU core when ``n_workers`` is
+omitted. Pass a fixed value when a scheduler or container limits the number of
+processes available to the job:
+
+.. code-block:: python
+
+  import birdnet
+
+  if __name__ == "__main__":
+      model = birdnet.load("acoustic", "2.4", "tf")
+      predictions = model.predict("example/soundscapes/", n_workers=2)
+      predictions.to_csv("example/predictions.csv")
+
+Each call to ``predict`` shuts down its producer and worker processes before it
+returns, including when inference raises an exception. To process several batches
+without restarting two workers for every batch, reuse a prediction session:
+
+.. code-block:: python
+
+  import birdnet
+
+  if __name__ == "__main__":
+      model = birdnet.load("acoustic", "2.4", "tf")
+
+      with model.predict_session(n_workers=2) as session:
+          first = session.run("example/soundscapes/day-1/")
+          second = session.run("example/soundscapes/day-2/")
+
+      first.to_csv("example/day-1.csv")
+      second.to_csv("example/day-2.csv")
   
 Predict species for a given location and time
 ---------------------------------------------

--- a/src/birdnet/acoustic/models/v2_4/model.py
+++ b/src/birdnet/acoustic/models/v2_4/model.py
@@ -511,11 +511,16 @@ class AcousticModelV2_4(AcousticModelBase):
     """Run prediction with the BirdNET 2.4 model on files or paths with configurable
     inference options.
 
+    This method creates one prediction session for the call. The session shuts down
+    its producer and worker processes before this method returns, including when
+    inference raises an exception.
+
     Args:
       inp: Path(s) or string(s) pointing to audio files to analyze.
       top_k: Number of highest-confidence results to return per segment.
       n_producers: Threads tasked with producing audio batches.
-      n_workers: Optional worker count for backend processing.
+      n_workers: Number of inference worker processes. ``None`` uses the number of
+        physical CPU cores. Pass a fixed integer to meet a process limit.
       batch_size: Number of records evaluated per inference call.
       prefetch_ratio: How many batches to decode ahead of processing.
       overlap_duration_s: Seconds of overlap between sliding windows.

--- a/src/birdnet/acoustic/models/v3_0/model.py
+++ b/src/birdnet/acoustic/models/v3_0/model.py
@@ -504,6 +504,16 @@ class AcousticModelV3_0(AcousticModelBase):
     segment_size_s: float = _DEFAULT_SEGMENT_SIZE_S,
     on_file_complete: Callable[[AcousticFilePredictionResult], None] | None = None,
   ) -> AcousticPredictionResultBase:
+    """Run prediction with the BirdNET 3.0 model on files or paths.
+
+    ``n_workers`` sets the number of inference worker processes. Its default value,
+    ``None``, uses the number of physical CPU cores. Pass a fixed integer to meet a
+    scheduler or container process limit.
+
+    This method creates one prediction session for the call. That session shuts down
+    its producer and worker processes before this method returns, including when
+    inference raises an exception.
+    """
     input_files = InferenceConfig.validate_input_files(inp)
     with self.predict_session(
       top_k=top_k,

--- a/src/birdnet_tests/documentation/test_prediction_docs.py
+++ b/src/birdnet_tests/documentation/test_prediction_docs.py
@@ -1,0 +1,34 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).parents[3]
+
+
+@pytest.mark.parametrize(
+  ("relative_path", "class_name"),
+  [
+    ("src/birdnet/acoustic/models/v2_4/model.py", "AcousticModelV2_4"),
+    ("src/birdnet/acoustic/models/v3_0/model.py", "AcousticModelV3_0"),
+  ],
+)
+def test_predict_documents_worker_limit_and_cleanup(
+  relative_path: str, class_name: str
+) -> None:
+  module = ast.parse((REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8"))
+  model = next(
+    node
+    for node in module.body
+    if isinstance(node, ast.ClassDef) and node.name == class_name
+  )
+  predict = next(
+    node
+    for node in model.body
+    if isinstance(node, ast.FunctionDef) and node.name == "predict"
+  )
+  docstring = ast.get_docstring(predict) or ""
+
+  assert "n_workers" in docstring
+  assert "physical CPU cores" in docstring
+  assert "shuts down" in docstring


### PR DESCRIPTION
## Summary

- Explain that `n_workers=None` uses the physical CPU core count and show `n_workers=2` for scheduler limits.
- Document per-call process cleanup and `predict_session` reuse across multiple batches.
- Check the 2.4 and 3.0 `predict` docstrings with a regression test.

## Tests

- `python -m pytest src/birdnet_tests/documentation/test_prediction_docs.py -q` (2 passed)
- `python -m ruff check src/birdnet/acoustic/models/v2_4/model.py src/birdnet/acoustic/models/v3_0/model.py src/birdnet_tests/documentation/test_prediction_docs.py`
- `python -m ruff format --check src/birdnet/acoustic/models/v2_4/model.py src/birdnet/acoustic/models/v3_0/model.py src/birdnet_tests/documentation/test_prediction_docs.py`

Closes #56
